### PR TITLE
"ECN field" not "ECN bits"

### DIFF
--- a/draft-ietf-tsvwg-udp-ecn.md
+++ b/draft-ietf-tsvwg-udp-ecn.md
@@ -60,7 +60,7 @@ Windows platforms.
 
 # Introduction
 
-{{?RFC3168}} reserves two bits in the IP header for Explicit Congestion
+{{?RFC3168}} defines a two-bit field in the IP header for Explicit Congestion
 Notification (ECN), which provides network feedback to endpoint congestion
 controllers. This has historically mostly been relevant to TCP ({{?RFC9293}}),
 where any incoming ECN codepoints are internally consumed by the kernel, and
@@ -92,7 +92,7 @@ and does not bind platforms to any API, or suggest any such API.
 
 Many socket APIs continue to reference the "ToS (Type of Service) byte" even
 though {{?RFC2474}} obsoleted that 25 years ago. That 8-bit field now contains a
-6-bit Differentiated Services Code Point (DSCP), in addition to the ECN bits.
+6-bit Differentiated Services Code Point (DSCP), in addition to the 2-bit ECN field.
 
 This document focuses on the APIs for the C and C++ languages. Other languages
 are likely to have different syntax and capabilities.


### PR DESCRIPTION
Some online references still refer to the obsoleted "ECT bit" and the "CE bit" and say things like:

> The CE bit is marked by routers experiencing imminent congestion. When the CE bit in a packet is set, it indicates that congestion was encountered along the path, and this packet serves as a direct notification to end points that they should take measures to reduce their data transmission rates.  [source](https://orhanergun.net/breaking-down-ecn-technical-deep-dive-into-congestion-control-mechanisms)

or:

> One bit is set by the source to indicate that it is ECN-capable, that is, able to react to a congestion notification. This is called the ECT bit (ECN-Capable Transport). The other bit is set by routers along the end-to-end path when congestion is encountered, as computed by whatever AQM algorithm it is running. This is called the CE bit (Congestion Encountered). [source](https://www.sciencedirect.com/topics/computer-science/explicit-congestion-notification)

We should avoid perpetuating that language.